### PR TITLE
refactor: getenv함수 이용해서 환경변수 찾는 로직으로 변경

### DIFF
--- a/execute/execute.c
+++ b/execute/execute.c
@@ -2,16 +2,18 @@
 
 int	execute(t_shell *shell_info)
 {
-//	int		origin_stdin;
-//	int		origin_stdout;
+	int		origin_stdin;
+	int		origin_stdout;
 	t_exec *exec_info;
 
 	exec_info = init_exec(shell_info);
-//	origin_stdin = dup(STDIN_FILENO);
-//	origin_stdout = dup(STDOUT_FILENO);
+	origin_stdin = dup(STDIN_FILENO);
+	origin_stdout = dup(STDOUT_FILENO);
 	if (shell_info->pipe_cnt == 0)
 		single_process(shell_info, exec_info);
 	else
 		multi_process(shell_info, exec_info);
+	dup2(origin_stdin, STDIN_FILENO);
+	dup2(origin_stdout, STDOUT_FILENO);
 	return (SUCCESS);
 }

--- a/execute/get_path.c
+++ b/execute/get_path.c
@@ -1,17 +1,11 @@
 #include "../minishell.h"
 
-char	**get_path(t_exec *exec_info)
+char	**get_path(void)
 {
-	t_env	*node;
+	char *path;
 
-	node = *exec_info->env;
-	while (node)
-	{
-		if (ft_strncmp(node->key, "PATH", 4) == TRUE)
-			break ;
-		node = node->next;
-	}
-	if (node == NULL || node->value == NULL)
+	path = getenv("PATH");
+	if (path == NULL)
 		return (NULL);
-	return (ft_split((char const *)node->value, ':'));
+	return (ft_split(path, ':'));
 }

--- a/execute/init_exec.c
+++ b/execute/init_exec.c
@@ -7,6 +7,6 @@ t_exec 	*init_exec(t_shell *shell_info)
 	exec_info = malloc(sizeof(t_exec));
 	ft_memset(exec_info, 0, sizeof(t_exec));
 	exec_info->env = &(shell_info->env);
-	exec_info->path = get_path(exec_info);
+	exec_info->path = get_path();
 	return (exec_info);
 }

--- a/minishell.h
+++ b/minishell.h
@@ -93,7 +93,7 @@ int execute(t_shell *shell_info);
 char	*get_cmd_path(char *cmd, char **path);
 
 // [execute/get_path.c]
-char	**get_path(t_exec *exec_info);
+char	**get_path(void);
 
 // [execute/init_exec.c]
 t_exec 	*init_exec(t_shell *shell_info);


### PR DESCRIPTION
- get_path 함수 리턴값이 null인 경우 발생해서 로직 수정.
- 직접 찾는 것 보단 기존에 있는 함수 사용하는 것이 더 안정성 있고 간편해 그렇게 수정함.
- multi process 실행시 그냥 종료되는 로직 수정