### PR TITLE
token_check.c에 토큰 생성 후 에러 확인하는 로직 추가

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ PARSE_SRCS =	parse_main.c\
 				./parse/env.c \
 				./parse/init.c \
 				./parse/parse_error.c \
+				./parse/token_check.c \
 
 
 SRCS	=	${EXEC_SRCS}\

--- a/minishell.h
+++ b/minishell.h
@@ -67,6 +67,9 @@ void free_redir(t_redir *redir);
 int check_quote(t_quote *quote, char c);
 void remove_outer_quotes(t_token **token);
 
+/*quote_check.c*/
+int validate_token(t_token **token);
+
 /*token.c*/
 void add_token_if_not_empty(char **start, char **current, t_token **token, t_type type);
 t_token *new_token(t_type type, char *value);

--- a/parse/parse_all.c
+++ b/parse/parse_all.c
@@ -5,30 +5,30 @@ int	parse_all(t_shell *shell_info, char *str)
 	t_token *token;
 	token = NULL;
 	init_shell(shell_info);
-	if (error_before_parse(token, str) == EXIT_FAILURE)
-		return (EXIT_FAILURE);
+	if (quote_error(str) != EXIT_SUCCESS)
+        return (EXIT_FAILURE);
 	parse_pipe(&token, str);
 	parse_redir(&token);
 	parse_space(&token);
 	parse_filename(&token);
 	remove_outer_quotes(&token);
-	// 앞으로 구현해야 할 것
-	// 5. token 순회하면서 invalid token 삭제 (token 없거나 에러 걸리면 token free하고 fail return)
-	// 6. envp update -> 은영 실행부에서 처리
-	// 7. cmd init 및 argument 저장
+	if (validate_token(&token) != EXIT_SUCCESS)
+		return (EXIT_FAILURE);
+	// 달러 처리해서 value값 치환한 상태로 넘겨주기
 	count_token_type(shell_info, token);
 	shell_info->cmd = tokens_to_cmds(token);
-	
+	//main 에서 set signal로 설정해주고 heredoc -> signal 처리 유의하기
+
 	///////////////////////////출력 확인 코드 모음///////////////////////////////
 
 	///////////////token 출력 확인 코드////////////////////
-	// t_token *current_token;
-	// current_token = token;
-    // while (current_token)
-    // {
-    //     printf("Type: %d, Value: [%s]\n", current_token->type, current_token->value);
-    //     current_token = current_token->next;
-    // }	
+	t_token *current_token;
+	current_token = token;
+    while (current_token)
+    {
+        printf("Type: %d, Value: [%s]\n", current_token->type, current_token->value);
+        current_token = current_token->next;
+    }	
 
 	///////////////////redir 출력 확인 코드///////////////////////////
 	// t_redir *current_redir;

--- a/parse/parse_error.c
+++ b/parse/parse_error.c
@@ -1,16 +1,5 @@
 #include "../minishell.h"
 
-int error_before_parse(t_token *token, char *str)
-{
-	t_token *tmp;
-
-	tmp = NULL;
-	if (!token)
-		return (quote_error(str));
-	tmp = tmp->next;
-	return (token_error(token));
-}
-
 int print_error_msg(void)
 {
 	ft_putstr_fd("minivell: syntax error\n", 2);

--- a/parse/token_check.c
+++ b/parse/token_check.c
@@ -1,0 +1,65 @@
+#include "../minishell.h"
+
+int check_pipe_error(t_token *token)
+{
+    while (token)
+    {
+        if (token->type == PIPE && (!token->next || token->next->type == PIPE))
+            return print_error_msg();
+        token = token->next;
+    }
+    return EXIT_SUCCESS;
+}
+
+int check_redir_sequence_error(t_token *token)
+{
+    while (token && token->next)
+    {
+        if ((token->type >= OUT_REDIR && token->type <= HEREDOC) &&
+            (token->next->type >= OUT_REDIR && token->next->type <= HEREDOC))
+            return print_error_msg();
+        token = token->next;
+    }
+    return EXIT_SUCCESS;
+}
+
+int check_heredoc_limit(t_token *token)
+{
+    int heredoc_count = 0;
+    while (token)
+    {
+        if (token->type == HEREDOC)
+            heredoc_count++;
+        if (heredoc_count >= 16)
+            return print_error_msg();
+        token = token->next;
+    }
+    return EXIT_SUCCESS;
+}
+
+int check_redir_filename_error(t_token *token)
+{
+    while (token && token->next)
+    {
+        if ((token->type >= OUT_REDIR && token->type <= HEREDOC) &&
+            token->next->type != FILENAME)
+            return print_error_msg();
+        token = token->next;
+    }
+    return EXIT_SUCCESS;
+}
+
+int validate_token(t_token **token)
+{
+    if (!token || !*token)
+        return EXIT_FAILURE;
+    if (check_pipe_error(*token) != EXIT_SUCCESS)
+        return EXIT_FAILURE;
+    if (check_redir_sequence_error(*token) != EXIT_SUCCESS)
+        return EXIT_FAILURE;
+    if (check_heredoc_limit(*token) != EXIT_SUCCESS)
+        return EXIT_FAILURE;
+    if (check_redir_filename_error(*token) != EXIT_SUCCESS)
+        return EXIT_FAILURE; 
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## 🌟 validate_token 함수로 token list 순회하며 검사

### 토큰들을 순회하면서 올바른 토큰이 생성되었는지 확인해주며, 올바르지 않은 값이 오면 syntax error을 출력하도록 해주었음

- token이 비어있는 경우
- pipe 뒤에 아무 인자가 없는 경우, pipe 두개가 연속으로 오는 경우
- redir이 연속으로 오는 경우
- heredoc이 16개 이상인 경우
- redir 뒤에 filename이 오지 않는 경우