### PR TITLE
remove_outer_quote 함수 분리 및 convert_env 함수 구현

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ PARSE_SRCS =	parse_main.c\
 				./parse/init.c \
 				./parse/parse_error.c \
 				./parse/token_check.c \
+				./parse/convert_env.c \
 
 
 SRCS	=	${EXEC_SRCS}\

--- a/minishell.h
+++ b/minishell.h
@@ -18,7 +18,6 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <fcntl.h>
-
 #include <readline/readline.h>
 #include <readline/history.h>
 
@@ -35,6 +34,10 @@ void init_shell(t_shell *shell_info);
 /*env.c*/
 void init_env(t_env **env, char *envp[]);
 
+/*convert_env.c*/
+char *find_env_value(t_env *env_list, char *key);
+void replace_env_variables_in_token(t_shell *shell_info, t_token *token);
+
 /*parse_pipe.c*/
 void parse_pipe(t_token **token, char *str);
 
@@ -49,7 +52,6 @@ int ft_isspace(int c);
 void parse_space(t_token **token);
 
 /*parse_error.c*/
-int error_before_parse(t_token *token, char *str);
 int print_error_msg(void);
 int quote_error(char *str);
 int token_error(t_token *token);

--- a/parse/cmd.c
+++ b/parse/cmd.c
@@ -10,8 +10,8 @@ t_cmd *tokens_to_cmds(t_token *tokens)
         if (tokens->type == PIPE || current_cmd == NULL)
         {
             t_cmd *new_cmd = (t_cmd *)malloc(sizeof(t_cmd));
-            new_cmd->cmd_args = (char **)malloc(sizeof(char *));  // NULL 포인터를 위한 공간 할당
-            new_cmd->cmd_args[0] = NULL;  // 첫 번째 요소를 NULL로 초기화
+            new_cmd->cmd_args = (char **)malloc(sizeof(char *));
+            new_cmd->cmd_args[0] = NULL;
             new_cmd->cmd_cnt = 0;
             new_cmd->redir = NULL;
             new_cmd->next = NULL;
@@ -29,8 +29,6 @@ t_cmd *tokens_to_cmds(t_token *tokens)
                 continue;
             }
         }
-
-        // 리다이렉션 토큰을 처리합니다
         if (tokens->type >= OUT_REDIR && tokens->type <= HEREDOC)
         {
             if (tokens->next && tokens->next->type == FILENAME)
@@ -38,14 +36,12 @@ t_cmd *tokens_to_cmds(t_token *tokens)
                 char *filename = ft_strdup(tokens->next->value);
                 t_redir *new = new_redir(tokens->type, filename);
                 add_back_redir(&(current_cmd->redir), new);
-                tokens = tokens->next;  // 파일 이름 토큰을 건너뜁니다
+                tokens = tokens->next;
             }
         }
         else
         {
-            char **new_args = (char **)malloc(sizeof(char *) * (current_cmd->cmd_cnt + 2));  // +1 개의 인자와 NULL을 위한 공간
-
-            // 기존 인자 복사
+            char **new_args = (char **)malloc(sizeof(char *) * (current_cmd->cmd_cnt + 2));
             if (current_cmd->cmd_args)
             {
                 ft_memcpy(new_args, current_cmd->cmd_args, sizeof(char *) * current_cmd->cmd_cnt);
@@ -53,14 +49,12 @@ t_cmd *tokens_to_cmds(t_token *tokens)
             }
 
             new_args[current_cmd->cmd_cnt] = ft_strdup(tokens->value);
-            new_args[current_cmd->cmd_cnt + 1] = NULL;  // 배열의 끝에 NULL 추가
-
+            new_args[current_cmd->cmd_cnt + 1] = NULL;
             current_cmd->cmd_args = new_args;
             current_cmd->cmd_cnt++;
         }
 
         tokens = tokens->next;
     }
-
     return head_cmd;
 }

--- a/parse/convert_env.c
+++ b/parse/convert_env.c
@@ -1,0 +1,16 @@
+#include "../minishell.h"
+
+int convert_env_len(char *str, int i)
+{
+	int len;
+
+	len = 0;
+	while (str[i] && str[i] != ' ' && str[i] != '$' && str[i] != '\"' && str[i] != '\'' && str[i] != '\\')
+	{
+		if (str[i] == '\0')
+			return (len);
+		len++;
+		i++;
+	}
+	return (len);
+}

--- a/parse/convert_env.c
+++ b/parse/convert_env.c
@@ -1,16 +1,31 @@
 #include "../minishell.h"
 
-int convert_env_len(char *str, int i)
+char *find_env_value(t_env *env_list, char *key) 
 {
-	int len;
-
-	len = 0;
-	while (str[i] && str[i] != ' ' && str[i] != '$' && str[i] != '\"' && str[i] != '\'' && str[i] != '\\')
+    while (env_list != NULL) 
 	{
-		if (str[i] == '\0')
-			return (len);
-		len++;
-		i++;
-	}
-	return (len);
+        if (ft_strncmp(env_list->key, key, ft_strlen(key) + 1))
+		{
+            return env_list->value;
+        }
+        env_list = env_list->next;
+    }
+    return NULL;
+}
+
+void replace_env_variables_in_token(t_shell *shell_info, t_token *token) 
+{
+    while (token != NULL) {
+        if (token->value[0] == '$') 
+		{
+            char *env_var_name = token->value + 1;
+            char *env_value = find_env_value(shell_info->env, env_var_name);
+
+            if (env_value != NULL) {
+                free(token->value);
+                token->value = ft_strndup(env_value, ft_strlen(env_value));
+            }
+        }
+        token = token->next;
+    }
 }

--- a/parse/parse_all.c
+++ b/parse/parse_all.c
@@ -10,11 +10,15 @@ int	parse_all(t_shell *shell_info, char *str)
 	parse_pipe(&token, str);
 	parse_redir(&token);
 	parse_space(&token);
-	parse_filename(&token);
 	remove_outer_quotes(&token);
+
+	// 토큰 순회하면서 enum type 최종적으로 재정의 -> bug: 따옴표 안에 있는 값들은 다 word 처리 되어있음
+	parse_filename(&token);
+	
 	if (validate_token(&token) != EXIT_SUCCESS)
 		return (EXIT_FAILURE);
 	// 달러 처리해서 value값 치환한 상태로 넘겨주기
+	replace_env_variables_in_token(shell_info, token);
 	count_token_type(shell_info, token);
 	shell_info->cmd = tokens_to_cmds(token);
 	//main 에서 set signal로 설정해주고 heredoc -> signal 처리 유의하기

--- a/parse/quote.c
+++ b/parse/quote.c
@@ -14,38 +14,52 @@ int check_quote(t_quote *quote, char c)
     return (quote->quote_flag);
 }
 
-void remove_outer_quotes(t_token **token_tmp) 
+int find_matching_quote(const char *str, int start_index, char quote_type)
 {
-    t_token *token = *token_tmp;
-    while (token)
+    int len = ft_strlen(str);
+    for (int j = start_index; j < len; j++) 
     {
-        char *str = token->value;
+        if (str[j] == quote_type)
+            return j;
+    }
+    return len;
+}
+
+void remove_quotes_from_string(char *str, char *new_str) 
+{
+    int len = ft_strlen(str);
+    int new_index = 0;
+    for (int i = 0; i < len; i++) 
+    {
+        if (str[i] == '\"' || str[i] == '\'') 
+        {
+            int j = find_matching_quote(str, i + 1, str[i]);
+            if (j < len)
+            {
+                i++;
+                while (i < j)
+                    new_str[new_index++] = str[i++];
+            } 
+            else
+                new_str[new_index++] = str[i];
+        } 
+        else 
+            new_str[new_index++] = str[i];
+    }
+    new_str[new_index] = '\0';
+}
+
+void remove_outer_quotes(t_token **token) 
+{
+    t_token *token_tmp = *token;
+    while (token_tmp) 
+    {
+        char *str = token_tmp->value;
         int len = ft_strlen(str);
         char *new_str = malloc(len + 1);
-        int new_index = 0;
-        for (int i = 0; i < len; i++) 
-        {
-            if (str[i] == '\"' || str[i] == '\'') 
-            {
-                char quote_type = str[i];
-                int j = i + 1;
-                while (j < len && str[j] != quote_type) 
-                    j++;
-                if (j < len) 
-                {
-                    i++;
-                    while (i < j) 
-                        new_str[new_index++] = str[i++];
-                } 
-                else 
-                    new_str[new_index++] = str[i];
-            } 
-            else 
-                new_str[new_index++] = str[i];
-        }
-        new_str[new_index] = '\0';
+        remove_quotes_from_string(str, new_str);
         ft_strlcpy(str, new_str, len + 1);
         free(new_str);
-        token = token->next;
+        token_tmp = token_tmp->next;
     }
 }


### PR DESCRIPTION
-remove_outer_quote 함수 다른 함수들로 분리해서 각각 line 수가 25줄 이내가 되도록 수정중

-quote 없는 기본 env 치환 완료 -> quote 처리 진행중

-">>" 와 같은 값이 들어올 경우 quote 제거 후 type이 그대로 WORD에서 바뀌지 않는 버그 발견 -> quote 제거 후 parse_filename 호출 이전에 전체 토큰을 순회하며 enum type을 재정의 하는 로직 필요함

